### PR TITLE
add logic for maker signing offchain transaction

### DIFF
--- a/Contracts/CrossChainHashedEscrow.sol
+++ b/Contracts/CrossChainHashedEscrow.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+/**
+ * @title CrossChainHashedEscrow
+ * @dev This contract facilitates cross-chain atomic swaps using a Hashed Timelock Contract (HTLC) pattern.
+ * It is designed to be deployed on two different chains to enable a trustless exchange of assets.
+ * The process is initiated by a taker executing a maker's signed off-chain order.
+ */
+contract CrossChainHashedEscrow is EIP712 {
+
+    enum HtlcStatus { Empty, Locked, Claimed, Refunded }
+
+    struct Htlc {
+        address initiator;      // The address that locked the funds
+        address recipient;      // The address that can claim the funds
+        address token;          // The ERC20 token locked in the escrow
+        uint256 amount;         // The amount of tokens locked
+        bytes32 hashedSecret;   // The hash of the secret key
+        uint256 timelock;       // The timestamp after which funds can be refunded
+        HtlcStatus status;      // The current status of the HTLC
+    }
+
+    struct SwapData {
+        address initiator;      // The user who wants to make the swap (the "maker")
+        address recipient;      // The user who will receive the tokens (the "taker")
+        address token;          // The ERC20 token to be swapped
+        uint256 amount;         // The amount of the token to be swapped
+        bytes32 hashedSecret;   // The hash of the secret key, provided by the maker
+        uint256 timelock;       // A deadline for the swap to be locked
+    }
+
+    mapping(bytes32 => Htlc) public swaps;
+
+    event Locked(bytes32 indexed swapId, address indexed initiator, address indexed recipient, address token, uint256 amount);
+    event Claimed(bytes32 indexed swapId, bytes32 secret);
+    event Refunded(bytes32 indexed swapId);
+
+    constructor() EIP712("CrossChainHashedEscrow", "1") {}
+
+    /**
+     * @dev Locks funds in the contract. This is called by the taker on behalf of the maker.
+     * @param swap The struct containing all the data for the swap, signed by the maker.
+     * @param signature The EIP-712 signature from the maker.
+     */
+    function lock(SwapData calldata swap, bytes calldata signature) external {
+        require(block.timestamp < swap.timelock, "Swap lock deadline expired");
+
+        bytes32 swapId = _getSwapId(swap);
+        require(swaps[swapId].status == HtlcStatus.Empty, "Swap already initiated");
+
+        address signer = _verifySignature(swapId, signature);
+        require(signer == swap.initiator, "Invalid signature from maker");
+
+        swaps[swapId] = Htlc({
+            initiator: swap.initiator,
+            recipient: swap.recipient,
+            token: swap.token,
+            amount: swap.amount,
+            hashedSecret: swap.hashedSecret,
+            timelock: block.timestamp + 24 hours, // Example: 24-hour refund timelock
+            status: HtlcStatus.Locked
+        });
+
+        IERC20(swap.token).transferFrom(swap.initiator, address(this), swap.amount);
+        emit Locked(swapId, swap.initiator, swap.recipient, swap.token, swap.amount);
+    }
+
+    /**
+     * @dev Allows the recipient to claim the locked funds by providing the secret.
+     * @param swapId The ID of the swap to claim.
+     * @param secret The secret key that hashes to the stored hashedSecret.
+     */
+    function claim(bytes32 swapId, bytes32 secret) external {
+        Htlc storage htlc = swaps[swapId];
+        require(htlc.status == HtlcStatus.Locked, "Swap not in locked state");
+        require(htlc.recipient == msg.sender, "Only recipient can claim");
+        require(htlc.hashedSecret == sha256(abi.encodePacked(secret)), "Invalid secret");
+        require(block.timestamp < htlc.timelock, "Timelock expired");
+
+        htlc.status = HtlcStatus.Claimed;
+        IERC20(htlc.token).transfer(htlc.recipient, htlc.amount);
+        emit Claimed(swapId, secret);
+    }
+
+    /**
+     * @dev Allows the initiator to get a refund if the swap was not claimed in time.
+     * @param swapId The ID of the swap to refund.
+     */
+    function refund(bytes32 swapId) external {
+        Htlc storage htlc = swaps[swapId];
+        require(htlc.status == HtlcStatus.Locked, "Swap not in locked state");
+        require(htlc.initiator == msg.sender, "Only initiator can refund");
+        require(block.timestamp >= htlc.timelock, "Timelock not yet expired");
+
+        htlc.status = HtlcStatus.Refunded;
+        IERC20(htlc.token).transfer(htlc.initiator, htlc.amount);
+        emit Refunded(swapId);
+    }
+
+    function _getSwapId(SwapData calldata swap) internal view returns (bytes32) {
+        return _hashTypedDataV4(keccak256(abi.encode(
+            keccak256("SwapData(address initiator,address recipient,address token,uint256 amount,bytes32 hashedSecret,uint256 timelock)"),
+            swap.initiator,
+            swap.recipient,
+            swap.token,
+            swap.amount,
+            swap.hashedSecret,
+            swap.timelock
+        )));
+    }
+
+    function _verifySignature(bytes32 digest, bytes calldata signature) internal view returns (address) {
+        return ECDSA.recover(digest, signature);
+    }
+}

--- a/Contracts/ERC20Mock.sol
+++ b/Contracts/ERC20Mock.sol
@@ -3,6 +3,10 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
+/**
+ * @title ERC20Mock
+ * @dev A mock ERC20 token for testing purposes.
+ */
 contract ERC20Mock is ERC20 {
     constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
 

--- a/Contracts/EscrowWithSignature.sol
+++ b/Contracts/EscrowWithSignature.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+/**
+ * @title EscrowWithSignature
+ * @dev This contract facilitates gas-less swaps. The maker signs a swap message off-chain,
+ * and a third-party taker/resolver can execute it on their behalf.
+ * The core security relies on the EIP-712 standard for typed data signing.
+ */
+contract EscrowWithSignature is EIP712 {
+    /**
+     * @dev The Swap struct defines the data that the maker will sign.
+     * It must match the structure defined in the off-chain signing script.
+     */
+    struct Swap {
+        address initiator; // The user who wants to make the swap (the "maker")
+        address recipient; // The user who will receive the tokens (the "taker")
+        address token;     // The ERC20 token to be swapped
+        uint256 amount;    // The amount of the token to be swapped
+        uint256 timelock;  // A deadline for the swap to be executed
+    }
+
+    // A mapping to prevent the same signature from being used twice (replay attack).
+    // The key is the EIP-712 hash of the Swap data.
+    mapping(bytes32 => bool) public executedSwaps;
+
+    event SwapExecuted(bytes32 indexed swapId, address indexed initiator, address indexed recipient, address token, uint256 amount);
+
+    /**
+     * @dev The constructor sets up the EIP-712 domain separator.
+     * This is crucial for signature verification and prevents replay attacks across different contracts.
+     * The name "Escrow" and "1" should match the domain data in the off-chain script.
+     */
+    constructor() EIP712("Escrow", "1") {}
+
+    /**
+     * @dev Executes a swap using a maker's signature.
+     * This function is called by the taker/resolver, who pays the gas fee.
+     * @param swap The struct containing all the data for the swap.
+     * @param signature The EIP-712 signature from the maker.
+     */
+    function execute(Swap calldata swap, bytes calldata signature) external {
+        require(block.timestamp < swap.timelock, "Swap timelock expired");
+
+        // 1. Hash the swap data struct to get the unique identifier for this swap.
+        bytes32 swapId = _hashTypedDataV4(keccak256(abi.encode(
+            keccak256("Swap(address initiator,address recipient,address token,uint256 amount,uint256 timelock)"),
+            swap.initiator,
+            swap.recipient,
+            swap.token,
+            swap.amount,
+            swap.timelock
+        )));
+
+        require(!executedSwaps[swapId], "Swap already executed");
+
+        // 2. Recover the signer's address from the signature and the hash.
+        address signer = ECDSA.recover(swapId, signature);
+        require(signer != address(0), "Invalid signature");
+
+        // 3. Authorize: Ensure the person who signed the message is the one initiating the swap.
+        require(signer == swap.initiator, "Signer is not the initiator");
+
+        // 4. Mark the swap as executed to prevent replay.
+        executedSwaps[swapId] = true;
+
+        // 5. Execute the token transfer. This requires the `swap.initiator` to have
+        // previously called `approve()` on the token contract, giving this Escrow
+        // contract the permission to spend tokens on their behalf.
+        IERC20(swap.token).transferFrom(swap.initiator, swap.recipient, swap.amount);
+
+        emit SwapExecuted(swapId, swap.initiator, swap.recipient, swap.token, swap.amount);
+    }
+}

--- a/scripts/approve_tokens.js
+++ b/scripts/approve_tokens.js
@@ -1,0 +1,60 @@
+
+const { ethers } = require("hardhat");
+
+async function main() {
+  console.log("--- Approving Tokens for the Escrow Contract ---");
+
+  // This would be the known, deployed address of your EscrowWithSignature contract
+  // For this example, we deploy it first to get an address.
+  const Escrow = await ethers.getContractFactory("EscrowWithSignature");
+  const escrow = await Escrow.deploy();
+  await escrow.waitForDeployment();
+  const escrowAddress = escrow.target;
+  console.log(`EscrowWithSignature contract deployed at: ${escrowAddress}`);
+
+  // We also need a token contract to approve.
+  const ERC20Mock = await ethers.getContractFactory("ERC20Mock");
+  const token = await ERC20Mock.deploy("Mock Token", "MTK");
+  await token.waitForDeployment();
+  const tokenAddress = token.target;
+  console.log(`Mock Token deployed at: ${tokenAddress}`);
+
+  const [maker] = await ethers.getSigners();
+  console.log(`Maker address: ${maker.address}`);
+
+  // Mint some tokens for the maker
+  const mintAmount = ethers.parseEther("10000");
+  await token.mint(maker.address, mintAmount);
+  console.log(`Minted ${ethers.formatEther(mintAmount)} tokens for the maker`);
+
+  // The amount to approve. Using a large number is common to avoid re-approving.
+  const approveAmount = ethers.parseEther("1000");
+
+  console.log(`
+[INFO] Maker will now send an on-chain transaction to approve the Escrow contract.`);
+  console.log(`   - Token: ${tokenAddress}`);
+  console.log(`   - Spender: ${escrowAddress}`);
+  console.log(`   - Amount: ${ethers.formatEther(approveAmount)} tokens`);
+
+  // The actual approval transaction
+  const tx = await token.connect(maker).approve(escrowAddress, approveAmount);
+  await tx.wait();
+
+  console.log("\n✅ Approval transaction successful!");
+  console.log(`Transaction hash: ${tx.hash}`);
+
+  // Verify the allowance
+  const allowance = await token.allowance(maker.address, escrowAddress);
+  console.log(`
+Current allowance for Escrow contract: ${ethers.formatEther(allowance)} tokens`);
+  console.log("\n--- Setup Complete ---");
+  console.log("The maker can now create off-chain signatures for swaps.");
+
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/create_maker_signature.js
+++ b/scripts/create_maker_signature.js
@@ -1,0 +1,73 @@
+const { ethers } = require("hardhat");
+
+// --- CONFIGURATION ---
+// In a real application, these addresses would come from a configuration file.
+const ESCROW_CONTRACT_ADDRESS = "0x5FbDB2315678afecb367f032d93F642f64180aa3"; // PASTE YOUR DEPLOYED EscrowWithSignature ADDRESS HERE
+const TOKEN_CONTRACT_ADDRESS = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512";  // PASTE YOUR DEPLOYED TOKEN ADDRESS HERE
+// ---------------------
+
+async function main() {
+  console.log("--- Preparing to create a maker signature ---");
+
+  if (!ESCROW_CONTRACT_ADDRESS || !TOKEN_CONTRACT_ADDRESS) {
+    console.error("ERROR: Please paste the deployed contract addresses in the script!");
+    return;
+  }
+
+  const [maker, taker] = await ethers.getSigners();
+  console.log("Maker (signer) address:", maker.address);
+  console.log("Taker (recipient) address:", taker.address);
+
+  const escrow = await ethers.getContractAt("EscrowWithSignature", ESCROW_CONTRACT_ADDRESS);
+  const token = await ethers.getContractAt("ERC20Mock", TOKEN_CONTRACT_ADDRESS);
+
+  console.log(`Using Escrow contract at: ${escrow.target}`);
+  console.log(`Using Token contract at: ${token.target}`);
+
+  const domain = {
+    name: "Escrow",
+    version: "1",
+    chainId: (await ethers.provider.getNetwork()).chainId,
+    verifyingContract: escrow.target
+  };
+
+  const types = {
+    Swap: [
+        { name: "initiator", type: "address" },
+        { name: "recipient", type: "address" },
+        { name: "token", type: "address" },
+        { name: "amount", type: "uint256" },
+        { name: "timelock", type: "uint256" },
+    ]
+  };
+
+  const timelock = Math.floor(Date.now() / 1000) + 3600; // Expires in 1 hour
+
+  const swapData = {
+    initiator: maker.address,
+    recipient: taker.address,
+    token: token.target,
+    amount: ethers.parseEther("50"), // A smaller amount for a specific swap
+    timelock: timelock,
+  };
+
+  console.log("\n[INFO] The maker will now sign the following data structure:");
+  console.log(swapData);
+
+  const signature = await maker.signTypedData(domain, types, swapData);
+
+  console.log("\n✅ Signature created successfully!");
+  console.log("Signature:", signature);
+
+  console.log("\n--- Next Steps ---");
+  console.log("The 'swapData' object and the 'signature' can now be given to the taker.");
+  console.log("The taker will call the 'execute' function on the Escrow contract.");
+
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/execute_signed_swap.js
+++ b/scripts/execute_signed_swap.js
@@ -1,0 +1,88 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+    console.log("--- Starting Full End-to-End Test Flow for execute_signed_swap.js ---");
+
+    // 1. SETUP: Deploy contracts and get signers
+    const [maker, taker] = await ethers.getSigners();
+    console.log(`Maker: ${maker.address}, Taker: ${taker.address}`);
+
+    const Escrow = await ethers.getContractFactory("EscrowWithSignature");
+    const escrow = await Escrow.deploy();
+    await escrow.waitForDeployment();
+    const escrowAddress = escrow.target;
+    console.log(`EscrowWithSignature deployed to: ${escrowAddress}`);
+
+    const ERC20Mock = await ethers.getContractFactory("ERC20Mock");
+    const token = await ERC20Mock.deploy("Mock Token", "MTK");
+    await token.waitForDeployment();
+    const tokenAddress = token.target;
+    console.log(`Mock Token deployed to: ${tokenAddress}`);
+
+    // 2. MINT & APPROVE: The maker prepares their tokens
+    const mintAmount = ethers.parseEther("5000");
+    await token.connect(maker).mint(maker.address, mintAmount);
+    console.log(`Minted ${ethers.formatEther(mintAmount)} MTK for Maker`);
+
+    const approveAmount = ethers.parseEther("100");
+    await token.connect(maker).approve(escrowAddress, approveAmount);
+    console.log(`Maker approved Escrow to spend ${ethers.formatEther(approveAmount)} MTK`);
+    
+    const initialTakerBalance = await token.balanceOf(taker.address);
+    console.log(`Initial Taker Balance: ${ethers.formatEther(initialTakerBalance)} MTK`);
+
+
+    // 3. SIGN: The maker creates the off-chain signature
+    const domain = {
+        name: "Escrow",
+        version: "1",
+        chainId: (await ethers.provider.getNetwork()).chainId,
+        verifyingContract: escrowAddress
+    };
+
+    const types = {
+        Swap: [
+            { name: "initiator", type: "address" },
+            { name: "recipient", type: "address" },
+            { name: "token", type: "address" },
+            { name: "amount", type: "uint256" },
+            { name: "timelock", type: "uint256" },
+        ]
+    };
+
+    const swapData = {
+        initiator: maker.address,
+        recipient: taker.address,
+        token: tokenAddress,
+        amount: ethers.parseEther("50"),
+        timelock: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    const signature = await maker.signTypedData(domain, types, swapData);
+    console.log(`
+Maker created signature: ${signature}`);
+
+
+    // 4. EXECUTE: The taker submits the swap to the blockchain
+    console.log("\nTaker is executing the swap...");
+    const tx = await escrow.connect(taker).execute(swapData, signature);
+    await tx.wait();
+    console.log("✅ Swap executed successfully!");
+    console.log(`Transaction hash: ${tx.hash}`);
+
+    // 5. VERIFY: Check the final balances
+    const finalMakerBalance = await token.balanceOf(maker.address);
+    const finalTakerBalance = await token.balanceOf(taker.address);
+
+    console.log("\n--- Final Balances ---");
+    console.log(`Maker\'s new balance: ${ethers.formatEther(finalMakerBalance)} MTK`);
+    console.log(`Taker\'s new balance: ${ethers.formatEther(finalTakerBalance)} MTK`);
+    console.log("--- Test Complete ---");
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/scripts/full_test_flow.js
+++ b/scripts/full_test_flow.js
@@ -1,0 +1,87 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+    console.log("--- Starting Full End-to-End Test Flow ---");
+
+    // 1. SETUP: Deploy contracts and get signers
+    const [maker, taker] = await ethers.getSigners();
+    console.log(`Maker: ${maker.address}, Taker: ${taker.address}`);
+
+    const Escrow = await ethers.getContractFactory("EscrowWithSignature");
+    const escrow = await Escrow.deploy();
+    await escrow.waitForDeployment();
+    const escrowAddress = escrow.target;
+    console.log(`EscrowWithSignature deployed to: ${escrowAddress}`);
+
+    const ERC20Mock = await ethers.getContractFactory("ERC20Mock");
+    const token = await ERC20Mock.deploy("Mock Token", "MTK");
+    await token.waitForDeployment();
+    const tokenAddress = token.target;
+    console.log(`Mock Token deployed to: ${tokenAddress}`);
+
+    // 2. MINT & APPROVE: The maker prepares their tokens
+    const mintAmount = ethers.parseEther("5000");
+    await token.connect(maker).mint(maker.address, mintAmount);
+    console.log(`Minted ${ethers.formatEther(mintAmount)} MTK for Maker`);
+
+    const approveAmount = ethers.parseEther("100");
+    await token.connect(maker).approve(escrowAddress, approveAmount);
+    console.log(`Maker approved Escrow to spend ${ethers.formatEther(approveAmount)} MTK`);
+    
+    const initialTakerBalance = await token.balanceOf(taker.address);
+    console.log(`Initial Taker Balance: ${ethers.formatEther(initialTakerBalance)} MTK`);
+
+
+    // 3. SIGN: The maker creates the off-chain signature
+    const domain = {
+        name: "Escrow",
+        version: "1",
+        chainId: (await ethers.provider.getNetwork()).chainId,
+        verifyingContract: escrowAddress
+    };
+
+    const types = {
+        Swap: [
+            { name: "initiator", type: "address" },
+            { name: "recipient", type: "address" },
+            { name: "token", type: "address" },
+            { name: "amount", type: "uint256" },
+            { name: "timelock", type: "uint256" },
+        ]
+    };
+
+    const swapData = {
+        initiator: maker.address,
+        recipient: taker.address,
+        token: tokenAddress,
+        amount: ethers.parseEther("50"),
+        timelock: Math.floor(Date.now() / 1000) + 3600,
+    };
+
+    const signature = await maker.signTypedData(domain, types, swapData);
+    console.log(`\nMaker created signature: ${signature}`);
+
+
+    // 4. EXECUTE: The taker submits the swap to the blockchain
+    console.log("\nTaker is executing the swap...");
+    const tx = await escrow.connect(taker).execute(swapData, signature);
+    await tx.wait();
+    console.log("✅ Swap executed successfully!");
+    console.log(`Transaction hash: ${tx.hash}`);
+
+    // 5. VERIFY: Check the final balances
+    const finalMakerBalance = await token.balanceOf(maker.address);
+    const finalTakerBalance = await token.balanceOf(taker.address);
+
+    console.log("\n--- Final Balances ---");
+    console.log(`Maker's new balance: ${ethers.formatEther(finalMakerBalance)} MTK`);
+    console.log(`Taker's new balance: ${ethers.formatEther(finalTakerBalance)} MTK`);
+    console.log("--- Test Complete ---");
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });


### PR DESCRIPTION
# Description
Through this PR we are to able to achieve the offchain transaction made by maker. This provides us the flexibility and power to get the best return for the swap as any resolver can participate in swap
For now simple contract is added that transfer tokens to recipient by taking input the offchain data swap data Contracts/EscrowWithSignature.sol

# Scripts
approve_tokens.js                   
create_maker_signature.js                                          
execute_signed_swap.js                                             
full_test_flow.js   
These scripts will help in testing the following contracts:
1. EscrowWithSignature.sol
2. ERC20Mock.sol


For now we are also storing the previous contracts, for reference in future